### PR TITLE
Fix: Build looped infinitely when endian_check failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ objs/$(ENDIAN_CHECK): src/endian_check.cpp
 
 src/endian.h: objs/$(ENDIAN_CHECK)
 	$(_E) [ENDIAN] Determining endianness
-	$(_C)objs/$(ENDIAN_CHECK) $(ENDIAN_PARAMS) > src/endian.h || rm src/endian.h
+	$(_C)objs/$(ENDIAN_CHECK) $(ENDIAN_PARAMS) > src/endian.h || { rm src/endian.h; exit 1; }
 
 FORCE:
 %_r: FORCE


### PR DESCRIPTION
When endian_check fails during the build, any generated endian.h file is
removed. However, this causes the entire command pipeline to return
success rather than failure and causes make to retry running
endian_check infinitely.

To fix this, an explicit `exit 1` is added to preserve the failure
status (though not the exact exit code) of endian_check.

This problem was first reported (and the fix suggested) at
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=922625

To reproduce, apply this patch and run `make`:
```
--- a/src/endian_check.cpp
+++ b/src/endian_check.cpp
@@ -36,5 +36,5 @@ int main (int argc, char *argv[])
                "#endif /* ENDIAN_H */\n",
                endian, endian);

-       return 0;
+       return 1;
 }
```