### PR TITLE
Fix various issues with MinGW build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ FLAGS += -DMINGW
 endif
 
 # Sadly enough fmemopen is
-ifneq ($(shell grep fmemopen /usr/include/stdio.h 2> /dev/null | wc -l | sed "s/ *//"),0)
+ifneq ($(shell echo "#include <stdio.h>" | $(CXX) -E -x c++ - | grep fmemopen | wc -l | sed "s/ *//"),0)
 ifndef NO_FMEMOPEN
 FLAGS += -DWITH_FMEMOPEN
 endif

--- a/Makefile
+++ b/Makefile
@@ -34,32 +34,12 @@ ENDIAN_CHECK ?= endian_check$(EXE)
 
 TYPESIZE     ?= GCC32
 
-# Somewhat automatic detection of the correct boost include folder
-ifndef BOOST_INCLUDE
-BOOST_INCLUDE=$(shell \
-find /usr/include /usr/local/include /opt/local/include -maxdepth 1 -name 'boost-*' 2> /dev/null | sort -t - -k 2 | tail -n 1 )
-ifeq ($(BOOST_INCLUDE),)
-BOOST_INCLUDE=$(shell \
-( [ -d /usr/include/boost/date_time ] && echo /usr/include ) || \
-( [ -d /usr/local/include/boost/date_time ] && echo /usr/local/include ) || \
-( [ -d /opt/local/include/boost/date_time ] && echo /opt/local/include ) )
-endif
-endif
-
-ifeq ($(BOOST_INCLUDE),)
-BOOST_ERROR = echo Error: Boost not found. Compilation will fail.
-endif
-
 ifndef V
 V=0 # verbose build default off
 endif
 
 ifndef FLAGS
-ifeq ($(ISCYGWIN),1)
-FLAGS = -I $(BOOST_INCLUDE) -O2
-else
-FLAGS = -idirafter$(BOOST_INCLUDE) -O2
-endif
+FLAGS = -O2
 FLAGS += -D$(TYPESIZE) -D_FORTIFY_SOURCE=2
 FLAGS += -Wall -Wextra -Wno-format-nonliteral
 
@@ -196,7 +176,6 @@ distclean: mrproper
 	$(_C)rm -rf Makefile.local
 
 FORCE:
-	@$(BOOST_ERROR)
 
 include version.def
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 
 ifndef FLAGS
 FLAGS = -O2
-FLAGS += -D$(TYPESIZE) -D_FORTIFY_SOURCE=2
+FLAGS += -D$(TYPESIZE) -D_FORTIFY_SOURCE=2 -fstack-protector
 FLAGS += -Wall -Wextra -Wno-format-nonliteral
 
 ifeq ($(DEBUG),1)

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ ifeq ($(DEBUG),1)
 FLAGS += -DDEBUG
 endif
 
-ifeq ($(MACHINE),mingw32)
+ifneq (,$(findstring mingw32,$(MACHINE)))
 FLAGS += -DMINGW
 endif
 

--- a/src/act123.h
+++ b/src/act123.h
@@ -98,6 +98,7 @@ private:
 		explicit range(uint max):min(0,max),max(max,max){}
 		range(const range&right):min(right.min),max(right.max){}
 		range(uint rangemax,uint minval,uint maxval):min(minval,rangemax),max(maxval,rangemax){}
+		range&operator=(const range&right){min=right.min; max=right.max; return *this;}
 		RangedUint min,max;
 	}dflt;
 public:

--- a/src/act123_classes.cpp
+++ b/src/act123_classes.cpp
@@ -293,6 +293,7 @@ void varRange::UpdateRange(uint Var,uint op,uint shift,const PseudoSprite&data,u
 	case 5:// max
         dflt.min=max(dflt.min,var.min);
         dflt.max=max(dflt.max,var.max);
+	/* FALLTHROUGH */
 	case 8:// /
 		if(var.min==0){
 			dflt.min=0;

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -1148,6 +1148,8 @@ FILE*_myfopen(files file, bool write){
 			exit(EDATA);
 		}
 	} else
+#else
+	(void)write;
 #endif /* WITH_FMEMOPEN */
 	{
 		pFile = tryopen(data[file].name,"wb");

--- a/src/grfcodec.cpp
+++ b/src/grfcodec.cpp
@@ -1007,6 +1007,7 @@ int main(int argc, char **argv)
 			break;
 		case 's':
 			_interactive = false;
+			break;
 		case 'X':
 			_hexspritenums=true;
 			break;

--- a/src/grfid.cpp
+++ b/src/grfid.cpp
@@ -19,7 +19,7 @@
 #define PROT_READ 0
 #define MAP_PRIVATE 0
 /* Lets fake mmap for Windows, please! */
-void *mmap (void *ptr, long size, long prot, long type, long handle, long arg) {
+void *mmap (void * /*ptr*/, long size, long /*prot*/, long /*type*/, long handle, long /*arg*/) {
 	char *mem = (char*)malloc(size + 1);
 	mem[size] = 0;
 	FILE *in = fdopen(handle, "rb");
@@ -31,7 +31,7 @@ void *mmap (void *ptr, long size, long prot, long type, long handle, long arg) {
 	fclose(in);
 	return mem;
 }
-long munmap (void *ptr, long size) {
+long munmap (void *ptr, long /*size*/) {
 	free(ptr);
 	return 0;
 }

--- a/src/grfstrip.cpp
+++ b/src/grfstrip.cpp
@@ -19,7 +19,7 @@
 #define PROT_READ 0
 #define MAP_PRIVATE 0
 /* Lets fake mmap for Windows, please! */
-void *mmap (void *ptr, long size, long prot, long type, long handle, long arg) {
+void *mmap (void * /*ptr*/, long size, long /*prot*/, long /*type*/, long handle, long /*arg*/) {
 	char *mem = (char*)malloc(size + 1);
 	mem[size] = 0;
 	FILE *in = fdopen(handle, "rb");
@@ -31,7 +31,7 @@ void *mmap (void *ptr, long size, long prot, long type, long handle, long arg) {
 	fclose(in);
 	return mem;
 }
-long munmap (void *ptr, long size) {
+long munmap (void *ptr, long /*size*/) {
 	free(ptr);
 	return 0;
 }

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -90,6 +90,7 @@ string vIssueMessage(int minSan,RenumMessageId id,va_list& arg_ptr){
 		case FATAL:
 		case ERROR:
 			prefix=minSan==FATAL?PREFIX_LINT_FATAL:PREFIX_LINT_ERROR;
+			/* FALLTHROUGH */
 		case WARNING1:
 		case WARNING2:
 		case WARNING3:

--- a/src/path.cpp
+++ b/src/path.cpp
@@ -11,6 +11,7 @@ static int DotFound(const char *pB)
 	case ':'  :
 		if (*(pB-2) != '\0')
 			break;
+		/* FALLTHROUGH */
 	case '/'  :
 	case '\\' :
 	case '\0' :
@@ -102,6 +103,7 @@ int fnsplit(const char *pathP, char *driveP, char *dirP,
 		case ':'  :
 			if (pB != &buf[2])
 				continue;
+			/* FALLTHROUGH */
 		case '\0' :
 			if (Wrk) {
 				if (*++pB)
@@ -110,6 +112,7 @@ int fnsplit(const char *pathP, char *driveP, char *dirP,
 				*pB-- = 0;
 				break;
 			}
+			/* FALLTHROUGH */
 		case '/'  :
 		case '\\' :
 			if (!Wrk) {
@@ -126,6 +129,7 @@ int fnsplit(const char *pathP, char *driveP, char *dirP,
 		case '?'  :
 			if (!Wrk)
 				Ret |= WILDCARDS;
+			/* FALLTHROUGH */
                 default :
 			continue;
 		}

--- a/src/pseudo.cpp
+++ b/src/pseudo.cpp
@@ -196,6 +196,7 @@ PseudoSprite::PseudoSprite(const string&sprite,int oldspritenum):
 				return;
 			}
 			//fall through to default when !GetState(EXTENSIONS)
+			/* FALLTHROUGH */
 		default:
 			if (is_comment(in)) {
 				string comment;
@@ -846,7 +847,7 @@ uint PseudoSprite::ReadValue(istream& in, width w) {
 
 		try {
 			return (date((ushort)y, (ushort)m, (ushort)d) - date(1920, 1, 1)).days() + extra;
-		} catch (std::out_of_range) {
+		} catch (std::out_of_range&) {
 			// Fall through to fail
 		}
 	}

--- a/src/readinfo.cpp
+++ b/src/readinfo.cpp
@@ -379,6 +379,7 @@ Pseudo::Pseudo(size_t num,int infover,int grfcontversion,const string&sprite,int
 				}}
 				throw Sprite::unparseable("Could not parse unquoted escape sequence",num);
 			}
+			/* FALLTHROUGH */
 		default:
 			ch=(char)ReadHex(in,2);
 			if(!in)
@@ -467,7 +468,7 @@ uint Pseudo::ReadValue(istream& in, width w)
 
 		try {
 			return (date((ushort)y, (ushort)m, (ushort)d) - date(1920, 1, 1)).days() + extra;
-		} catch (std::out_of_range) {
+		} catch (std::out_of_range&) {
 			// Fall through to fail
 		}
 	}


### PR DESCRIPTION
Most compilation warnings fixed. (Almost) no changes in behaviour - added an obviously missing `break`. Other than that, I've tried to keep to the _lovely_ codestyle.

Two remaining warnings that I haven't quite figured out, as they would require some thought on my part:

```
[CPP] objs/grfcomm.o
In file included from src/grfcomm.cpp:10:
In function 'char* strncpy(char*, const char*, size_t)',
    inlined from 'char* spritefilename(const char*, const char*, const char*, int, const char*, int)' at src/grfcomm.cpp:216:9:
C:/msys64/mingw64/x86_64-w64-mingw32/include/string.h:240:33: warning: 'char* __builtin_strncpy(char*, const char*, long long unsigned int)' specified bound 1024 equals destination size [-Wstringop-truncation]
  240 |   return __builtin___strncpy_chk(__dst, __src, __n, __mingw_bos(__dst, 1));
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function 'char* strncpy(char*, const char*, size_t)',
    inlined from 'int getspritefilename(char*, const char*, char*, const char*, long int)' at src/grfcomm.cpp:216:9,
    inlined from 'char* spritefilename(const char*, const char*, const char*, int, const char*, int)' at src/grfcomm.cpp:114:19:
C:/msys64/mingw64/x86_64-w64-mingw32/include/string.h:240:33: warning: 'char* __builtin_strncpy(char*, const char*, long long unsigned int)' output may be truncated copying 2 bytes from a string of length 2 [-Wstringop-truncation]
  240 |   return __builtin___strncpy_chk(__dst, __src, __n, __mingw_bos(__dst, 1));
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

(Because the message isn't clear, they correspond to https://github.com/OpenTTD/grfcodec/blob/e8b95a39190fc64c150228401654c26f96da60da/src/grfcomm.cpp#L113 and https://github.com/OpenTTD/grfcodec/blob/e8b95a39190fc64c150228401654c26f96da60da/src/grfcomm.cpp#L51 respectively)