### PR TITLE
Update all deprecated stuff

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install dependencies
       run: |
@@ -75,7 +75,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Prepare cache key
       id: key
@@ -83,7 +83,7 @@ jobs:
         echo "::set-output name=image::$ImageOS-$ImageVersion"
 
     - name: Enable vcpkg cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /usr/local/share/vcpkg/installed
         key: ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}-0 # Increase the number whenever dependencies are modified
@@ -131,7 +131,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Prepare cache key
       id: key
@@ -143,7 +143,7 @@ jobs:
         Write-Output "::set-output name=image::$env:ImageOS-$env:ImageVersion"
 
     - name: Enable vcpkg cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: vcpkg/installed
         key: ${{ steps.key.outputs.image }}-vcpkg-${{ matrix.arch }}-0 # Increase the number whenever dependencies are modified

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -124,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, windows-2016]
+        os: [windows-latest, windows-2019]
         arch: [x86, x64]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Prepare cache key
       id: key
       run: |
-        echo "::set-output name=image::$ImageOS-$ImageVersion"
+        echo "image=$ImageOS-$ImageVersion" >> $GITHUB_OUTPUT
 
     - name: Enable vcpkg cache
       uses: actions/cache@v3
@@ -140,7 +140,7 @@ jobs:
         # Work around caching failure with GNU tar
         New-Item -Type Junction -Path vcpkg -Target c:\vcpkg
 
-        Write-Output "::set-output name=image::$env:ImageOS-$env:ImageVersion"
+        Write-Output "image=$env:ImageOS-$env:ImageVersion" >> $env:GITHUB_OUTPUT
 
     - name: Enable vcpkg cache
       uses: actions/cache@v3

--- a/.github/workflows/commit-checker.yml
+++ b/.github/workflows/commit-checker.yml
@@ -15,37 +15,7 @@ jobs:
         fetch-depth: 4
 
     - name: Get pull-request commits
-      run: |
-        set -x
-        # actions/checkout did a merge checkout of the pull-request. As such, the first
-        # commit is the merge commit. This means that on HEAD^ is the base branch, and
-        # on HEAD^2 are the commits from the pull-request. We now check if those trees
-        # have a common parent. If not, we fetch a few more commits till we do. In result,
-        # the log between HEAD^ and HEAD^2 will be the commits in the pull-request.
-        DEPTH=4
-        while [ -z "$(git merge-base HEAD^ HEAD^2)" ]; do
-            # Prevent infinite recursion
-            if [ ${DEPTH} -gt 256 ]; then
-                echo "No common parent between '${GITHUB_HEAD_REF}' and '${GITHUB_BASE_REF}'." >&2
-                exit 1
-            fi
-
-            git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --deepen=${DEPTH} origin HEAD
-            DEPTH=$(( ${DEPTH} * 4 ))
-        done
-
-        # Just to show which commits we are going to evaluate.
-        git log --oneline HEAD^..HEAD^2
-
-    - name: Checkout commit-checker
-      uses: actions/checkout@v3
-      with:
-        repository: OpenTTD/OpenTTD-git-hooks
-        path: git-hooks
-        ref: master
+      uses: OpenTTD/actions/checkout-pull-request@v2
 
     - name: Check commits
-      run: |
-        set -x
-        HOOKS_DIR=./git-hooks/hooks GIT_DIR=.git ./git-hooks/hooks/check-commits.sh HEAD^..HEAD^2
-        echo "Commit checks passed"
+      uses: OpenTTD/OpenTTD-git-hooks@main

--- a/.github/workflows/commit-checker.yml
+++ b/.github/workflows/commit-checker.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 4
 
@@ -38,7 +38,7 @@ jobs:
         git log --oneline HEAD^..HEAD^2
 
     - name: Checkout commit-checker
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: OpenTTD/OpenTTD-git-hooks
         path: git-hooks


### PR DESCRIPTION
`set-output` and node12 are deprecated, so update is required.
`windows-2016` (VS2017) image has been removed on March 15th.
`windows-latest` is `windows-2022` (VS2022) so CI is no longer testing with VS2019.