### PR TITLE
Change: make DOS TTD palette the default, instead of TT Original Mars landscape

### DIFF
--- a/src/grfcodec.cpp
+++ b/src/grfcodec.cpp
@@ -900,7 +900,7 @@ static U8* findpal(char *grffile)
 			return defaultpalettes[defpals[i].defpalno];
 	}
 
-	return defaultpalettes[0];
+	return defaultpalettes[PAL_ttd_norm];
 }
 
 //extern "C" void debugint(void);


### PR DESCRIPTION
grfcodec uses some compile time magic to populate the 'ttdpal.h' file from a number of files in a folder.

When you decode a grf, do not specify a palette, and the palette is not hardcoded in a small filename-lookup table, then the first palette will be used. Given the order in the CMakeLists.txt, this would be the TT Original Mars landscape palette. 

In my opinion it is more likely that the DOS TTD is used. Primarily because it is supported by both TTDPatch and OpenTTD, and it boasts most colours.