### PR TITLE
Fix: Palettes must be defined in a specific order, not sorted by filename.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,12 +95,12 @@ add_custom_target(version_header
 
 # Target to generate ttpal.h
 set(PALETTE_SOURCE_FILES
-	${CMAKE_CURRENT_SOURCE_DIR}/src/pals/tt1_mars.bcp
-	${CMAKE_CURRENT_SOURCE_DIR}/src/pals/tt1_norm.bcp
-	${CMAKE_CURRENT_SOURCE_DIR}/src/pals/ttd_cand.bcp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/pals/ttd_norm.bcp
-	${CMAKE_CURRENT_SOURCE_DIR}/src/pals/ttw_cand.bcp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/pals/ttw_norm.bcp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/pals/ttd_cand.bcp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/pals/ttw_cand.bcp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/pals/tt1_norm.bcp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/pals/tt1_mars.bcp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/pals/ttw_pb_pal1.bcp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/pals/ttw_pb_pal2.bcp
 )


### PR DESCRIPTION
## Motivation

Old versions of grfcodec has the palettes defined in a specific order.

This got lost (probably with the move to CMake), and the palettes are sorted in the CMakeLists.txt by filename alphabetically.

```
Built-in palettes: use -p <number>, where <number> is one of the following:
	4  DOS TTD
	6  Windows TTD
	3  DOS TTD, Candyland
	5  Windows TTD, Candyland
	2  TT Original
	1  TT Original, Mars landscape
```

## Description

Adjust CMakeLists.txt to get back to the intended order.

```
Built-in palettes: use -p <number>, where <number> is one of the following:
	1  DOS TTD
	2  Windows TTD
	3  DOS TTD, Candyland
	4  Windows TTD, Candyland
	5  TT Original
	6  TT Original, Mars landscape
```