### PR TITLE
Cleanup: Fix some warnings

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -19,7 +19,7 @@ jobs:
           - compiler: gcc
             cxxcompiler: g++
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: ${{ matrix.compiler }}
       CXX: ${{ matrix.cxxcompiler }}

--- a/src/grfid.cpp
+++ b/src/grfid.cpp
@@ -9,7 +9,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <filesystem>
 #include <fstream>
 #include <vector>
 

--- a/src/pcxsprit.cpp
+++ b/src/pcxsprit.cpp
@@ -172,9 +172,9 @@ void pcxwrite::showspriteno()
 	char spritenum[10];
 	int newlastx;
 	if(_hexspritenums)
-		sprintf(spritenum, "%X", spriteno);
+		snprintf(spritenum, sizeof(spritenum), "%X", spriteno);
 	else
-		sprintf(spritenum, "%d", spriteno);
+		snprintf(spritenum, sizeof(spritenum), "%d", spriteno);
 
 	newlastx = subx+strlen(spritenum)*(DIGITWIDTH+1)+dx;
 	if (newlastx >= pcxfile::sx)

--- a/src/pseudo.cpp
+++ b/src/pseudo.cpp
@@ -791,15 +791,15 @@ uint PseudoSprite::ReadValue(istream& in, width w) {
 			return 0;
 		}
 		int val, err = 0;
-		size_t s = in.tellg();
+		auto s = in.tellg();
 		val = DoCalc(in.ignore(),err);
 		if (err>0)
 			return 0;
 
 		// Replace the original RPN with value
-		size_t e = in.tellg(),
-			p = orig.find(((istringstream&)in).str().substr(s, e - s));
-		orig.erase(p, e - s);
+		auto e = in.tellg();
+		size_t p = orig.find(((istringstream&)in).str().substr(size_t(s), size_t(e - s)));
+		orig.erase(p, size_t(e - s));
 		ostringstream Val;
 		Val << val;
 		orig.insert(p, Val.str());

--- a/src/sprites.cpp
+++ b/src/sprites.cpp
@@ -201,7 +201,6 @@ void SpriteInfo::writetobuffer(U8 *buffer, int grfcontversion)
 
 void SpriteInfo::readfromfile(const char *action, int grfcontversion, FILE *grf, int spriteno)
 {
-	int i = 0;
 	if (grfcontversion == 2) {
 		U8 data = fgetc(grf);
 		/* According to the documentation bit 0 must always be set, and bits 3 and 6 are the same as in the nfo. */
@@ -217,7 +216,6 @@ void SpriteInfo::readfromfile(const char *action, int grfcontversion, FILE *grf,
 		}
 		this->zoom = fgetc(grf);
 		this->ydim = readword(action, grf);
-		i += 2;
 	} else {
 		this->info = fgetc(grf);
 		this->depth = DEPTH_8BPP;


### PR DESCRIPTION
First commit fixes `The contents of <filesystem> are available only with C++17 or later.` I had with VS2022.

Second commit is for `'initializing': conversion from 'std::streamoff' to 'size_t', possible loss of data` (MSVC x86).

Third commit is for `variable 'i' set but not used [-Wunused-but-set-variable]` (reported only by macos clang).

Fourth commit is for `'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]` (reported only by macos).

Fifth commit is because gcc 9 is too old to support fourth commit.