### PR TITLE
Change: Support decoding of NewGRF with out-of-order v2 container and 32bpp-only files.

### DIFF
--- a/src/sprites.cpp
+++ b/src/sprites.cpp
@@ -394,14 +394,14 @@ int decodesprite(FILE *grf, spritestorage *imgpal, spritestorage *imgrgba, sprit
 				printf("\nError: cannot decode 32bpp sprites to pcx\n");
 				exit(2);
 			}
-			writesprite(false, imgrgba, writer, imgbuffer, info);
+			writesprite(i == 0, imgrgba, writer, imgbuffer, info);
 		} else if (info.depth==DEPTH_MASK) {
 			if (imgrgba == NULL) {
 				printf("\nError: cannot decode 32bpp sprites to pcx\n");
 				exit(2);
 			}
 			info.depth=DEPTH_32BPP;
-			writesprite(false, imgrgba, writer, imgbuffer, info);
+			writesprite(i == 0, imgrgba, writer, imgbuffer, info);
 			info.depth=DEPTH_MASK;
 			writesprite(false, imgpal, writer, imgbuffer, info);
 		} else if (info.depth==DEPTH_8BPP) {

--- a/src/sprites.h
+++ b/src/sprites.h
@@ -91,7 +91,7 @@ class spritestorage {
 
 extern int maxx, maxy, maxs;
 
-int decodesprite(FILE *grf, spritestorage *imgpal, spritestorage *imgrgba, spriteinfowriter *writer, int spriteno, U32 *dataoffset, int grfcontversion);
+int decodesprite(FILE *grf, spritestorage *imgpal, spritestorage *imgrgba, spriteinfowriter *writer, int spriteno, int grfcontversion);
 
 long getlasttilesize();
 long encodetile(U8 **compressed_data, long *uncompressed_size, const CommonPixel *image, long imgsize, int sx, int sy, SpriteInfo inf, int docompress, int spriteno, bool has_mask, bool rgba, int grfcontversion);


### PR DESCRIPTION
GRFCodec assumes v2 container data is used sequentially, however this is not enforced by OpenTTD and some existing NewGRFs are able to use data out of order, or reuse it.

OpenTTD allows this by prescanning all v2 container data and storing the offset for each ID, and I have copied the basic principle from there. Note that, in the case of reusing data, GRFCodec is not aware of this and will happily output multiple copies of the same sprite data. This may be something to address in future but for now simply the ability to decode is nice.

Additionally, previously GRFCodec did not properly export 32bpp files as the condition for outputting the correct nfo line for the first sprite was only used on the line that writes 8bpp sprites. This was added to the 32bpp lines as well, so that 32bpp-only NewGRFs can be decoded.

Note that GRFCodec already does not enforce that an 8bpp is present when encoding, so it was possible for GRFCodec to create a file that it could not decode.

While the NFO specs mention that an 8bpp normal zoom level sprite is required first, this is not checked by GRFCodec, and importantly, it is not checked by OpenTTD either.

The NewGRF file at the following link was used when testing this:

https://bananas.openttd.org/package/newgrf/524f4231