### PR TITLE
Codechange: Silence clang warnings about va_start

### DIFF
--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -71,9 +71,10 @@ string mysprintf(const char*str,...){
 static RenumMessageId curMessage;
 #endif
 
-string IssueMessage(int minSan,RenumMessageId id,...){
+string internal::IssueMessage(int minSan,...){
 	va_list ap;
-	va_start(ap, id);
+	va_start(ap, minSan);
+	RenumMessageId id = (RenumMessageId)va_arg(ap, int);
 	string result = vIssueMessage(minSan,id,ap);
 	va_end(ap);
 	return result;

--- a/src/messages.h
+++ b/src/messages.h
@@ -83,7 +83,13 @@
 // -------
 
 std::string vIssueMessage(int,RenumMessageId,std::va_list&);
-std::string IssueMessage(int,RenumMessageId,...);
+namespace internal {
+	std::string IssueMessage(int,...);
+}
+template<typename... Targs>
+std::string IssueMessage(int minSan,RenumMessageId id,Targs... Fargs) {
+	return internal::IssueMessage(minSan,id,Fargs...);
+};
 void AutoConsoleMessages();
 void ManualConsoleMessages();
 std::string mysprintf(const char*,...);

--- a/src/sanity.cpp
+++ b/src/sanity.cpp
@@ -150,9 +150,10 @@ void Before8(int action){
 	}
 }
 
-bool CheckLength(int alen,int elen,RenumMessageId message,...){
+bool internal::CheckLength(int alen,int elen,...){
 	va_list ap;
-	va_start(ap, message);
+	va_start(ap, elen);
+	RenumMessageId message = (RenumMessageId)va_arg(ap, int);
 	if(alen<elen){
 		vIssueMessage(FATAL,message,ap);
 		return true;

--- a/src/sanity_defines.h
+++ b/src/sanity_defines.h
@@ -23,8 +23,13 @@
 #define _RENUM_SANITY_DEFS_H_INCLUDED_
 
 #include "message_mgr.h"
-
-bool CheckLength(int,int,RenumMessageId,...);
+namespace internal {
+	bool CheckLength(int,int,...);
+}
+template<typename... Targs>
+bool CheckLength(int alen,int elen,RenumMessageId id,Targs... Fargs) {
+	return internal::CheckLength(alen,elen,id,Fargs...);
+}
 bool CheckTextID(uint,uint,uint);
 bool CheckID(uint,uint);
 


### PR DESCRIPTION
Fixes `passing an object that undergoes default argument promotion to 'va_start' has undefined behavior [-Wvarargs]`