### PR TITLE
Change: Allow stripping 8bpp normal zoom with grfstrip.

### DIFF
--- a/src/grfstrip.cpp
+++ b/src/grfstrip.cpp
@@ -175,7 +175,7 @@ int main(int argc, char **argv)
 			"\n"
 			"Usage:\n"
 			"    GRFSTRIP <origin> <dest> (<depth> <zoom>)*\n"
-			"        Strip real sprites that are not in the set \"normal 8bpp and the ones\n"
+			"        Strip real sprites that are not in the set \"the ones\n"
 			"        specified at the command line\" from origin into dest.\n"
 			"        Known depths: ");
 		for (int j = 0; j < num_depths; j++) {
@@ -200,7 +200,7 @@ int main(int argc, char **argv)
 		return 0;
 	}
 
-	uint32_t allowed = 1;
+	uint32_t allowed = 0;
 	for (int i = 3; i + 1 < argc; ) {
 		int depth_offset = 0xFF;
 		for (int j = 0; j < num_depths; j++) {


### PR DESCRIPTION
## Motivation / Problem

grfstrip does not allow stripping 8bpp normal zoom sprite.

## Description

8bpp normal zoom sprites are not required by OpenTTD, so allow them to be stripped by setting the default allowed value to 0.

## Limitations

This could potentially break workflows that use grfstrip and want to keep 8bpp normal zoom sprites without specifying it in the list. 

But who uses this?