### PR TITLE
Fix: potential undefined behaviour when subtracting null pointer

### DIFF
--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -53,6 +53,7 @@
 
 #include "md5.h"
 #include <string.h>
+#include <cstdint>
 
 #undef BYTE_ORDER	/* 1 = big-endian, -1 = little-endian, 0 = unknown */
 #ifdef ARCH_IS_BIG_ENDIAN
@@ -161,7 +162,7 @@ md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
 	     * On little-endian machines, we can process properly aligned
 	     * data without copying it.
 	     */
-	    if (!((data - (const md5_byte_t *)0) & 3)) {
+	    if (reinterpret_cast<std::uintptr_t>(data) & 3) {
 		/* data are properly aligned */
 		X = (const md5_word_t *)data;
 	    } else {


### PR DESCRIPTION
There is a warning on  src/md5.cpp#L164: 
"performing pointer subtraction with a null pointer may have undefined behavior [-Wnull-pointer-subtraction]".

This warning/potential UB is solved by reinterpreting the pointer as a `std::uintptr_t` and checking that value instead.
