### PR TITLE
Change: Allow encoding 32bpp-only sprites.

### DIFF
--- a/src/lang/message_english.h
+++ b/src/lang/message_english.h
@@ -278,7 +278,6 @@ NFO_MESSAGE(INVALID_ACT2_FLAGS,"Unknown flag set (offset %d) in advanced action2
 NFO_MESSAGE(NOT_IN_REALSPRITE,"Found realsprite continuation line while looking for sprite %d.\n",0)
 NFO_MESSAGE(REAL_UNKNOWN_FLAG,"Unknown or duplicate flag '%t'.\n",0)
 NFO_MESSAGE(REAL_DUPLICATE_ZOOM,"Duplicate zoomlevel/depth sprite.\n",0)
-NFO_MESSAGE(REAL_8BPP_NORMAL_FIRST,"8bpp normal zoom sprite must appear first.\n",0)
 NFO_MESSAGE(REAL_32BPP_BEFORE_MASK,"mask sprites must be preceded by 32bpp sprites.\n",0)
 NFO_MESSAGE(UNKNOWN_ACT0_DATA,"Unknown data does not allow processesing past this point.\n",USE_PREFIX|HAS_OFFSET)
 

--- a/src/nforenum.cpp
+++ b/src/nforenum.cpp
@@ -681,7 +681,6 @@ bool verify_real(string&data,RealSpriteState&formats){
 			format.bpp32 = depth=="32bpp";
 			format.zoom = zoom;
 
-			if (formats.present.empty()&&(format.bpp32||format.zoom!=0)) IssueMessage(0,REAL_8BPP_NORMAL_FIRST);
 			if (formats.present.count(format) > 0) { IssueMessage(0,REAL_DUPLICATE_ZOOM); return COMMENTOFF(); }
 			formats.present.insert(format);
 		} else {

--- a/src/readinfo.cpp
+++ b/src/readinfo.cpp
@@ -253,7 +253,6 @@ void Real::AddSprite(size_t sprite,int infover,const string&data){
 	inf.forcereopen=(inf.ypos<prevy);
 	prevy=inf.ypos;
 
-	if(infs.size()==0&&inf.zoom!=0)throw Sprite::unparseable("first sprite is not 8bpp normal zoom sprite",sprite);
 	if(inf.depth==DEPTH_MASK){
 		SpriteInfo parent=infs[infs.size()-1];
 		if (parent.depth!=DEPTH_32BPP)throw Sprite::unparseable("mask sprite not preceded by 32bpp sprite",sprite);


### PR DESCRIPTION
This makes (re)encoding GRFs without 8bpp sprites possible.

#29 allowed grfcodec to decode 32bpp-only NewGRFs, but it was not possible to then encode back to NewGRF again.

Will allow a non-TTDPatch-compatible NewGRF, but that's easily done already...