### PR TITLE
Fix: uploading of GRFcodec releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,3 +141,31 @@ jobs:
       run: |
         cd build
         gh release upload ${{ github.event.release.tag_name }} bundles/*
+
+  upload:
+    name: Upload
+    needs:
+    - source
+    - windows
+
+    runs-on: ubuntu-latest
+
+    # This job is empty, but ensures no upload job starts before all targets finished and are successful.
+    steps:
+    - name: Build completed
+      run: |
+        true
+
+  upload-cdn:
+    name: Upload (CDN)
+    needs:
+    - source
+    - upload
+
+    uses: ./.github/workflows/upload-cdn.yml
+    secrets: inherit
+
+    with:
+      version: ${{ needs.source.outputs.version }}
+      folder: ${{ needs.source.outputs.folder }}
+      trigger_type: ${{ needs.source.outputs.trigger_type }}

--- a/.github/workflows/upload-cdn.yml
+++ b/.github/workflows/upload-cdn.yml
@@ -1,0 +1,62 @@
+name: Upload (CDN)
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      folder:
+        required: true
+        type: string
+      trigger_type:
+        required: true
+        type: string
+
+jobs:
+  prepare:
+    name: Prepare
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download all bundles
+      uses: actions/download-artifact@v4
+
+    - name: Calculate checksums
+      run: |
+        echo "::group::Move bundles to a single folder"
+        mkdir bundles
+        mv grfcodec-*/* bundles/
+        echo "::endgroup::"
+
+        cd bundles
+        for i in $(ls grfcodec-*); do
+          echo "::group::Calculating checksums for ${i}"
+          openssl dgst -r -md5 -hex $i > $i.md5sum
+          openssl dgst -r -sha1 -hex $i > $i.sha1sum
+          openssl dgst -r -sha256 -hex $i > $i.sha256sum
+          echo "::endgroup::"
+        done
+
+    - name: Store bundles
+      uses: actions/upload-artifact@v4
+      with:
+        name: cdn-bundles
+        path: bundles/*
+        retention-days: 5
+
+  publish-bundles:
+    needs:
+    - prepare
+
+    name: Publish bundles
+    uses: OpenTTD/actions/.github/workflows/rw-cdn-upload.yml@v5
+    secrets:
+      CDN_SIGNING_KEY: ${{ secrets.CDN_SIGNING_KEY }}
+      DEPLOYMENT_APP_ID: ${{ secrets.DEPLOYMENT_APP_ID }}
+      DEPLOYMENT_APP_PRIVATE_KEY: ${{ secrets.DEPLOYMENT_APP_PRIVATE_KEY }}
+    with:
+      artifact-name: cdn-bundles
+      folder: ${{ inputs.folder }}
+      version: ${{ inputs.version }}


### PR DESCRIPTION
It would be preferable to just have GRFcodec releases at the "old" location, but the upload part has been lost when migrating to GitHub. This is a counterpart to OpenTTD/website#319, where this would be the better solution.

I copied bits from OpenTTD's code but I have no idea how to test this as I do not have access to any of the secrets required for uploading.

I hope @TrueBrain or @glx22 might be able to test whether this actually uploads and especially whether it uploads it to the right location. The right location being https://www.openttd.org/downloads/grfcodec-releases/latest for releases and https://www.openttd.org/downloads/grfcodec-nightlies/latest for the nightlies. Otherwise it'll be a lot of YOLO testing in production with nightlies I fear.